### PR TITLE
Add mobile app and services table

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ This template comes with [Tailwind CSS](https://tailwindcss.com/) already config
 ## Support
 
 If you get stuck along the way, get help in our [support forums](https://answers.netlify.com/).
+## Mobile Application
+
+A simple React Native application is available in the `mobile` directory. It allows users to sign up or log in and view available services from Supabase. See `mobile/README.md` for setup instructions.
+

--- a/USAGE.md
+++ b/USAGE.md
@@ -78,3 +78,18 @@ Next, add an authenticated user to log in to the template. In your Supabase proj
 Once you've completed this process, return to the login form and log in to the template. You should see the <strong>members</strong> that we just added to the database.
 
 ![Template with data](/public/guides/remix-dashboard.png)
+
+## Create the services table
+
+To manage the work that R.J.H-MAINTENANCE offers, create a `services` table in Supabase using the following SQL:
+
+```sql
+CREATE TABLE services (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  name TEXT NOT NULL,
+  description TEXT NOT NULL
+);
+```
+
+Add your own service records so they appear in the mobile application.

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.expo
+.DS_Store

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { View, Text, TextInput, Button, StyleSheet, FlatList } from 'react-native';
+import { createClient } from '@supabase/supabase-js';
+import Constants from 'expo-constants';
+
+const supabaseUrl = Constants.expoConfig.extra.supabaseUrl;
+const supabaseAnonKey = Constants.expoConfig.extra.supabaseAnonKey;
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export default function App() {
+  const [session, setSession] = useState(null);
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [services, setServices] = useState([]);
+
+  const signUp = async () => {
+    const { data, error } = await supabase.auth.signUp({ email, password });
+    if (error) {
+      alert(error.message);
+    } else {
+      setSession(data.session);
+      fetchServices();
+    }
+  };
+
+  const signIn = async () => {
+    const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      alert(error.message);
+    } else {
+      setSession(data.session);
+      fetchServices();
+    }
+  };
+
+  const fetchServices = async () => {
+    const { data } = await supabase.from('services').select('id, name, description');
+    setServices(data || []);
+  };
+
+  if (!session) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>R.J.H-MAINTENANCE</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          value={email}
+          onChangeText={setEmail}
+          autoCapitalize="none"
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Password"
+          value={password}
+          onChangeText={setPassword}
+          secureTextEntry
+        />
+        <View style={styles.buttonRow}>
+          <Button title="Sign In" onPress={signIn} />
+          <Button title="Sign Up" onPress={signUp} />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Available Work</Text>
+      <FlatList
+        data={services}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.card}>
+            <Text style={styles.cardTitle}>{item.name}</Text>
+            <Text>{item.description}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    justifyContent: 'center'
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    textAlign: 'center'
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  card: {
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 6,
+    marginBottom: 12
+  },
+  cardTitle: {
+    fontWeight: 'bold',
+    marginBottom: 4
+  }
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,24 @@
+# RJH Maintenance Mobile App
+
+This directory contains a simple React Native application built with [Expo](https://expo.dev/) for the R.J.H-MAINTENANCE company.
+
+## Setup
+
+1. Install dependencies (requires Node.js and npm):
+   ```bash
+   cd mobile
+   npm install
+   ```
+2. Set the Supabase environment variables in `app.config.js` or by using an `.env` file with the following values:
+   - `EXPO_PUBLIC_SUPABASE_URL`
+   - `EXPO_PUBLIC_SUPABASE_ANON_KEY`
+
+3. Start the development server:
+   ```bash
+   npm start
+   ```
+   Use the Expo CLI to run the app on an iOS simulator or a physical device.
+
+## Functionality
+
+Users can sign up or log in with their email and password. After authentication, the app displays a list of available services fetched from the `services` table in Supabase.

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -1,0 +1,14 @@
+/* eslint-env node */
+export default {
+  expo: {
+    name: 'RJH Maintenance',
+    slug: 'rjh-maintenance',
+    version: '1.0.0',
+    sdkVersion: '49.0.0',
+    platforms: ['ios', 'android'],
+    extra: {
+      supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL,
+      supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY,
+    },
+  },
+};

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "RJH Maintenance",
+    "slug": "rjh-maintenance",
+    "version": "1.0.0",
+    "sdkVersion": "49.0.0",
+    "platforms": ["ios", "android"],
+    "jsEngine": "hermes"
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "rjh-maintenance-mobile",
+  "private": true,
+  "version": "0.1.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "ios": "expo start --ios",
+    "android": "expo start --android",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@supabase/supabase-js": "^2.48.1"
+  }
+}

--- a/supabase/migrations/20250801231000_create_services_table.sql
+++ b/supabase/migrations/20250801231000_create_services_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE services (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  name TEXT NOT NULL,
+  description TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary
- add migration for `services` table
- document mobile application in README and setup in USAGE
- scaffold simple Expo app for iOS in `mobile` directory
- lint fixes for new mobile files

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688d48c1072c83249280d75b077d2cc3